### PR TITLE
Able to start monitor mode in aircrack-ng v1.2 rc2

### DIFF
--- a/wifite.py
+++ b/wifite.py
@@ -998,7 +998,7 @@ class RunEngine:
 
         proc = Popen(['airmon-ng'], stdout=PIPE, stderr=DN)
         for line in proc.communicate()[0].split('\n'):
-            if len(line) == 0 or line.startswith('Interface'): continue
+            if len(line) == 0 or line.startswith('Interface') or line.startswith('PHY'): continue
             monitors.append(line)
 
         if len(monitors) == 0:
@@ -1011,6 +1011,7 @@ class RunEngine:
 
         elif len(monitors) == 1:
             monitor = monitors[0][:monitors[0].find('\t')]
+            if monitor.startswith('phy'): monitor = monitors[0].split()[1]
             return self.enable_monitor_mode(monitor)
 
         print GR + " [+]" + W + " available wireless devices:"


### PR DESCRIPTION
For aircrack-ng v1.2 rc2, the output is now different.

## v1.2 rc2
```
root@kali ~/wifite$ airmon-ng
PHY	Interface	Driver		Chipset

phy1	wlan0		rtl8187		Realtek Semiconductor Corp. RTL8187
phy2	wlan1		rt2800usb	Edimax Technology Co., Ltd EW-7711UTn nLite [Ralink RT2870]

root@kali ~/wifite$
```

## v1.2 rc1
```
root@kali ~$ airmon-ng                                                                                                                                                   


Interface	Chipset		Driver

wlan0		Ralink RT2870/3070	rt2800usb - [phy0]
wlan1		Realtek RTL8187L	rtl8187 - [phy1]

root@kali ~$ 
```