### PR TITLE
Fix handshake detection when using tshark

### DIFF
--- a/wifite.py
+++ b/wifite.py
@@ -2340,7 +2340,7 @@ class WPAAttack(Attack):
             # Call Tshark to return list of EAPOL packets in cap file.
             cmd = ['tshark',
                    '-r', capfile,  # Input file
-                   '-R', 'eapol',  # Filter (only EAPOL packets)
+                   '-Y', 'eapol',  # Filter (only EAPOL packets)
                    '-n']  # Do not resolve names (MAC vendors)
             proc = Popen(cmd, stdout=PIPE, stderr=DN)
             proc.wait()


### PR DESCRIPTION
Latest versions of tshark suggest: "-Y ... Use this instead of -R for filtering using single-pass analysis."

This addresses issue #54.
